### PR TITLE
Remove errant character

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -26,7 +26,6 @@ The Model Context Protocol (MCP) is an open protocol that enables seamless integ
   - [Java SDK](https://github.com/modelcontextprotocol/java-sdk)
   - [Kotlin SDK](https://github.com/modelcontextprotocol/kotlin-sdk)
   - [C# SDK](https://github.com/modelcontextprotocol/csharp-sdk)
-)
 
 ## Project Structure
 


### PR DESCRIPTION
modelcontextprotocol/.github#223 introduced an errant closing parenthesis that was overlooked in the review.