### PR TITLE
Update Specification link in README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://modelcontextprotocol.io">Documentation</a> |
-  <a href="https://spec.modelcontextprotocol.io">Specification</a> |
+  <a href="https://modelcontextprotocol.io/specification">Specification</a> |
   <a href="https://github.com/orgs/modelcontextprotocol/discussions">Discussions</a>
 </p>
 
@@ -19,7 +19,7 @@ The Model Context Protocol (MCP) is an open protocol that enables seamless integ
 ## Getting Started
 
 - 📚 Read the [Documentation](https://modelcontextprotocol.io) for guides and tutorials
-- 🔍 Review the [Specification](https://spec.modelcontextprotocol.io) for protocol details
+- 🔍 Review the [Specification](https://modelcontextprotocol.io/specification) for protocol details
 - 💻 Use our SDKs to start building:
   - [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
   - [Python SDK](https://github.com/modelcontextprotocol/python-sdk)

--- a/profile/README.md
+++ b/profile/README.md
@@ -19,7 +19,7 @@ The Model Context Protocol (MCP) is an open protocol that enables seamless integ
 ## Getting Started
 
 - 📚 Read the [Documentation](https://modelcontextprotocol.io) for guides and tutorials
-- 🔍 Review the [Specification](https://modelcontextprotocol.io/specification) for protocol details
+- 🔍 Review the [Specification](https://modelcontextprotocol.io/specification/latest) for protocol details
 - 💻 Use our SDKs to start building:
   - [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
   - [Python SDK](https://github.com/modelcontextprotocol/python-sdk)

--- a/profile/README.md
+++ b/profile/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://modelcontextprotocol.io">Documentation</a> |
-  <a href="https://modelcontextprotocol.io/specification">Specification</a> |
+  <a href="https://modelcontextprotocol.io/specification/latest">Specification</a> |
   <a href="https://github.com/orgs/modelcontextprotocol/discussions">Discussions</a>
 </p>
 


### PR DESCRIPTION
The spec.modelcontextprotocol.io URL no longer works. This updates the org README at https://github.com/modelcontextprotocol/ to use a working link.