### PR TITLE
Fix project structure links in README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -34,7 +34,7 @@ The Model Context Protocol (MCP) is an open protocol that enables seamless integ
 
 ## Project Structure
 
-- [specification](https://github.com/modelcontextprotocol/specification) - Protocol specification and documentation
+- [modelcontextprotocol](https://github.com/modelcontextprotocol/modelcontextprotocol) - User documentation and protocol specification
 - [typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk) - TypeScript implementation
 - [python-sdk](https://github.com/modelcontextprotocol/python-sdk) - Python implementation
 - [java-sdk](https://github.com/modelcontextprotocol/java-sdk) - Java implementation
@@ -45,7 +45,6 @@ The Model Context Protocol (MCP) is an open protocol that enables seamless integ
 - [ruby-sdk](https://github.com/modelcontextprotocol/ruby-sdk) - Ruby implementation
 - [rust-sdk](https://github.com/modelcontextprotocol/rust-sdk) - Rust implementation
 - [swift-sdk](https://github.com/modelcontextprotocol/swift-sdk) - Swift implementation
-- [docs](https://github.com/modelcontextprotocol/docs) - User documentation and guides
 - [create-kotlin-server](https://github.com/modelcontextprotocol/kotlin-sdk/tree/main/samples/kotlin-mcp-server) - Kotlin sample server
 - [servers](https://github.com/modelcontextprotocol/servers) - List of maintained servers
 - [ext-auth](https://github.com/modelcontextprotocol/ext-auth) - List of authorization extensions


### PR DESCRIPTION
Updated the links in the project structure section to remove archived repo and link to current repo for spec and docs.

## Motivation and Context

/docs repo is currently archived, so its confusing to visit, all old code.

## How Has This Been Tested?

URL is a 200

## Breaking Changes

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
