### PR TITLE
Update About section to reference Linux Foundation

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -57,4 +57,4 @@ Have questions? Join the discussion in our [community forum](https://github.com/
 
 ## About
 
-The Model Context Protocol is an open source project run by [Anthropic, PBC.](https://anthropic.com) and open to contributions from the entire community.
+The Model Context Protocol is an open source project hosted by [The Linux Foundation](https://lfprojects.org) and open to contributions from the entire community.


### PR DESCRIPTION
MCP is now a Series of LF Projects, LLC. Updates the org README to reflect this.

Fixes the issue raised in https://anthropic.slack.com/archives/C090Q3LS0N9/p1766011830486849