### PR TITLE
Remove license section from CONTRIBUTING.md

### DIFF
--- a/profile/CONTRIBUTING.md
+++ b/profile/CONTRIBUTING.md
@@ -15,7 +15,3 @@ Please find the contribution guide for the repositories in the project in the re
 ## Code of Conduct
 
 Please note that this project is released with a [Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
-
-## License
-
-By contributing, you agree that your contributions will be licensed under the MIT License.


### PR DESCRIPTION
Licenses are now specified per-project, so this org-level statement is no longer accurate.

Related: https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/1995